### PR TITLE
Hardlink count should be handled only when this option is enabled in rsync

### DIFF
--- a/bpc_sysCalls.c
+++ b/bpc_sysCalls.c
@@ -32,6 +32,7 @@ static void *DataBufferFreeList = (void*)NULL;
 
 extern int am_generator;
 extern int always_checksum;
+extern int preserve_hard_links;
 extern int protocol_version;
 
 static bpc_attribCache_info acNew;
@@ -153,7 +154,7 @@ int bpc_sysCall_cleanup(void)
     if ( LogLevel >= 4 ) bpc_logMsgf("bpc_sysCall_cleanup: doneInit = %d\n", DoneInit);
     if ( !DoneInit ) return 0;
     if ( am_generator ) {
-        hard_link_bpc_update_link_count();
+        if(preserve_hard_links) hard_link_bpc_update_link_count();
         bpc_attribCache_flush(&acNew, 1, NULL);
         if ( acOldUsed ) bpc_attribCache_flush(&acOld, 1, NULL);
     }


### PR DESCRIPTION
When '--hard-links' isn't used in RsyncArgs, rsync_bpc will segfault after the file transfer:

/usr/local/bin/rsync_bpc --bpc-top-dir /data/BackupPC --bpc-host-name HOST --bpc-share-name / --bpc-bkup-num 165 --bpc-bkup-comp 3 --bpc-bkup-prevnum 164 --bpc-bkup-prevcomp 3 --bpc-bkup-inode0 5638 --bpc-attrib-new --bpc-log-level 7 -e /usr/bin/ssh\ -q\ -x\ -l\ root --rsync-path=/usr/bin/rsync --super --recursive --protect-args --numeric-ids --perms --owner --group -D --times --links --delete --partial --log-format=log:\ %o\ %i\ %B\ %8U,%8G\ %9l\ %f%L --stats --timeout=72000 --include=/etc --include=/root  --include=/var --include=/var/spool --include=/var/spool/cron --exclude=/\* --exclude=/var/\* --exclude=/var/spool/\* HOST:/ /
...
sent 45132 bytes  received 104663965 bytes  5107760.83 bytes/sec
total size is 104499974  speedup is 1.00
G bpc_sysCall_cleanup: doneInit = 1
Segmentation fault

I don't know if this fixes the issue entirely but for my scenario it does the trick. After this patch I didn't get segfault anymore.

Best regards,
Ovidiu