### PR TITLE
Do not set file mode

### DIFF
--- a/backuppc/bpc_poolWrite.c
+++ b/backuppc/bpc_poolWrite.c
@@ -778,7 +778,6 @@ void bpc_poolWrite_addToPool(bpc_poolWrite_info *info, char *fileName, int v3Poo
             unlink(lockFile);
             redo = 1;
         } else {
-            chmod(poolPath, 0444);
             stat(poolPath, &st);
             info->retValue     = v3PoolFile ? 2 : 0;
             info->poolFileSize = st.st_size;
@@ -823,7 +822,6 @@ void bpc_poolWrite_addToPool(bpc_poolWrite_info *info, char *fileName, int v3Poo
              * remove the original file and return
              */
             unlink(fileName);
-            chmod(poolPath, 0444);
             info->retValue     = v3PoolFile ? 2 : 0;
             info->poolFileSize = st.st_size;
             return;


### PR DESCRIPTION
File permissions should be set according to $Conf{UmaskMode}.
Umask is set before rsync_bpc is called so we should not set file mode via chmod(2).

See: https://github.com/backuppc/backuppc/issues/302