### PR TITLE
configure.ac: Avoid implicit int, implicit function declarations

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -392,7 +392,8 @@ AS_HELP_STRING([--disable-ipv6],[disable to omit ipv6 support]),
 #include <stdlib.h>
 #include <sys/types.h>
 #include <sys/socket.h>
-main()
+int
+main(void)
 {
    if (socket(AF_INET6, SOCK_STREAM, 0) < 0)
      exit(1);

--- a/configure.sh
+++ b/configure.sh
@@ -7706,7 +7706,8 @@ else $as_nop
 #include <stdlib.h>
 #include <sys/types.h>
 #include <sys/socket.h>
-main()
+int
+main(void)
 {
    if (socket(AF_INET6, SOCK_STREAM, 0) < 0)
      exit(1);


### PR DESCRIPTION
These obsolete C language features are not necessary support by C99 compilers.  Future compilers might disable them by default, to issue clearer diagnostic.  This commits prepares for that, so that the detected system properties do not change.

--------------------

I regenerated `configure.sh` using upstream autoconf 2.69. You will have to use your patched version to avoid additional changes.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
