### PR TITLE
Prevent xattr warning by reordering header inclusion

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -83,6 +83,7 @@ $(BPCOBJ): backuppc/backuppc.h
 $(OBJS): $(HEADERS)
 $(CHECK_OBJS): $(HEADERS)
 
+tls.o xattrs.o: lib/sysxattrs.h
 flist.o: rounding.h
 
 rounding.h: rounding.c rsync.h proto.h

--- a/lib/sysxattrs.h
+++ b/lib/sysxattrs.h
@@ -1,9 +1,9 @@
 #ifdef SUPPORT_XATTRS
 
-#if defined HAVE_ATTR_XATTR_H
-#include <attr/xattr.h>
-#elif defined HAVE_SYS_XATTR_H
+#if defined HAVE_SYS_XATTR_H
 #include <sys/xattr.h>
+#elif defined HAVE_ATTR_XATTR_H
+#include <attr/xattr.h>
 #elif defined HAVE_SYS_EXTATTR_H
 #include <sys/extattr.h>
 #endif


### PR DESCRIPTION
This fix adopts the changes made in rsync [pull request 22](https://github.com/RsyncProject/rsync/pull/22). This fix prevents the xattr header warning when building the project