### PR TITLE
pool_alloc: fix build with gcc-15

### DIFF
--- a/lib/pool_alloc.c
+++ b/lib/pool_alloc.c
@@ -9,7 +9,7 @@ struct alloc_pool
 	size_t			size;		/* extent size		*/
 	size_t			quantum;	/* allocation quantum	*/
 	struct pool_extent	*extents;	/* top extent is "live" */
-	void			(*bomb)();	/* function to call if
+	void			(*bomb)(const char *);	/* function to call if
 						 * malloc fails		*/
 	int			flags;
 


### PR DESCRIPTION
* fixes https://github.com/backuppc/rsync-bpc/issues/48

```
lib/pool_alloc.c: In function ‘pool_create’:
lib/pool_alloc.c:86:20: error: assignment to ‘void (*)(void)’ from incompatible pointer type ‘void (*)(const char *)’ [-Wincompatible-pointer-types]
   86 |         pool->bomb = bomb;
      |                    ^
lib/pool_alloc.c: In function ‘pool_alloc’:
lib/pool_alloc.c:172:18: error: too many arguments to function ‘pool->bomb’; expected 0, have 1
  172 |                 (*pool->bomb)(bomb_msg);
      |                 ~^~~~~~~~~~~~ ~~~~~~~~
lib/pool_alloc.c:12:35: note: declared here
   12 |         void                    (*bomb)();      /* function to call if
      |                                   ^~~~
```